### PR TITLE
Fix compilation issue

### DIFF
--- a/trustm_engine/trustm_engine_rsa.c
+++ b/trustm_engine/trustm_engine_rsa.c
@@ -258,8 +258,8 @@ static int trustmEngine_rsa_priv_enc(int flen,
     do 
     {
 	// OPTIGA Comms Shielded connection settings to enable the protection
-	OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
-	OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me, OPTIGA_COMMS_RESPONSE_PROTECTION);
+	OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me_crypt, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
+	OPTIGA_CRYPT_SET_COMMS_PROTECTION_LEVEL(me_crypt, OPTIGA_COMMS_RESPONSE_PROTECTION);
 
 	optiga_lib_status = OPTIGA_LIB_BUSY;
 	return_status = optiga_crypt_rsa_sign(me_crypt,


### PR DESCRIPTION
The master is not compiling because of a variable not renamed:

------ Generating application objects: trustm_engine/trustm_engine_rsa.c 
In file included from trustm_helper/include/trustm_helper.h:40,
                 from trustm_engine/trustm_engine_rsa.c:29:
trustm_engine/trustm_engine_rsa.c: In function 'trustmEngine_rsa_priv_enc':
trustm_engine/trustm_engine_rsa.c:261:42: error: 'me' undeclared (first use in this function)
  261 |  OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
      |                                          ^~
trustm_lib/optiga/include/optiga/optiga_crypt.h:1047:35: note: in definition of macro 'OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION'
 1047 |     optiga_crypt_set_comms_params(p_instance, \
      |                                   ^~~~~~~~~~
trustm_engine/trustm_engine_rsa.c:261:42: note: each undeclared identifier is reported only once for each function it appears in
  261 |  OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION(me, OPTIGA_COMMS_PROTOCOL_VERSION_PRE_SHARED_SECRET);
      |                                          ^~
trustm_lib/optiga/include/optiga/optiga_crypt.h:1047:35: note: in definition of macro 'OPTIGA_CRYPT_SET_COMMS_PROTOCOL_VERSION'
 1047 |     optiga_crypt_set_comms_params(p_instance, \
      |                                   ^~~~~~~~~~
make: *** [Makefile:179: trustm_engine/trustm_engine_rsa.o] Error 1
