### PR TITLE
Add compatiblity with linker --as-needed  option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,12 +155,12 @@ clean :
 $(BINDIR)/$(ENG): %: $(ENGOBJ) $(INCSRC) $(BINDIR)/$(LIB)
 	@echo "******* Linking $@ "
 	@mkdir -p bin
-	@$(CC) $(LDFLAGS) $(LDFLAGS_1) $(ENGOBJ) -shared -o $@
+	@$(CC) $(LDFLAGS_1) $(LDFLAGS) $(ENGOBJ) -shared -o $@
 
 $(APPS): %: $(OTHOBJ) $(INCSRC) $(BINDIR)/$(LIB) %.o
 	@echo "******* Linking $@ "
 	@mkdir -p bin
-	@$(CC) $(LDFLAGS) $(LDFLAGS_1) $@.o $(OTHOBJ) -o $@
+	@$(CC) $@.o $(LDFLAGS_1) $(LDFLAGS) $(OTHOBJ) -o $@
 	@cp $@ bin/.
 
 $(BINDIR)/$(LIB): %: $(LIBOBJ) $(INCSRC)


### PR DESCRIPTION
Yocto add some flags when compiling. Linker option, --as-needed, is one of them and it caused the compilation to fail because files/libraries was not given in the right order.