### PR TITLE
Fixes shmem existence check

### DIFF
--- a/trustm_helper/shared_mutex.c
+++ b/trustm_helper/shared_mutex.c
@@ -40,8 +40,6 @@ shared_mutex_t shared_mutex_init(const char *name)
   shared_mutex_t mutex = {NULL, 0, NULL, 0,NULL};
   trustm_mutex_t *addr;
   trustm_mutex_t *mutex_ptr;
-  errno = 0;
-  
 
   // Open existing shared memory object, or create one.
   // Two separate calls are needed here, to mark fact of creation
@@ -51,7 +49,7 @@ shared_mutex_t shared_mutex_init(const char *name)
   pthread_mutex_lock(&shm_lock); 
   TRUSTM_MUTEX_DBGFN("pthread lock successfully");
   mutex.shm_fd = shm_open(name, O_RDWR, 0660);
-  if (errno == ENOENT) {
+  if (mutex.shm_fd == -1 && errno == ENOENT) {
     mutex.shm_fd = shm_open(name, O_RDWR|O_CREAT, 0660);
     mutex.created = 1;
     TRUSTM_MUTEX_DBGFN("create new shm");


### PR DESCRIPTION
errno should not be checked on its own. Instead, the return value of
the function that will set errno should be evaluated prior to evaluating
errno.

see errno(3)
   The value in errno is significant only when the return value of
   the call indicated an error (i.e., -1 from most system calls; -1
   or NULL from most library functions); a function that succeeds is
   allowed to change errno.  The value of errno is never set to zero
   by any system call or library function.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Provide the information we need to review your PR. What problem does the pull request solve? "Bug fix" is not a good description.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.